### PR TITLE
databases: Check logic for the right settings

### DIFF
--- a/web3/apps/sites/views/databases.py
+++ b/web3/apps/sites/views/databases.py
@@ -74,14 +74,14 @@ def sql_database_view(request, site_id):
         return HttpResponse("feature disabled\n\n", content_type="text/plain")
 
     if site.database.category == "mysql":
-        if not settings.POSTGRES_DB_HOST:
-            return HttpResponse("Director has been improperly configured! (Missing POSTGRES_DB_HOST)", content_type="text/plain")
+        if not settings.MYSQL_DB_HOST:
+            return HttpResponse("Director has been improperly configured! (Missing MYSQL_DB_HOST)", content_type="text/plain")
 
         ret, out, err = run_as_site(site, ["mysql", "--user={}".format(site.database.username),
                                            "--host={}".format(settings.MYSQL_DB_HOST), site.database.db_name, "-e", sql], env={"MYSQL_PWD": site.database.password})
     else:
-        if not settings.MYSQL_DB_HOST:
-            return HttpResponse("Director has been improperly configured! (Missing MYSQL_DB_HOST)", content_type="text/plain")
+        if not settings.POSTGRES_DB_HOST:
+            return HttpResponse("Director has been improperly configured! (Missing POSTGRES_DB_HOST)", content_type="text/plain")
 
         ret, out, err = run_as_site(site, ["psql", str(site.database), "-c", sql], env={"SHELL": "/usr/sbin/nologin"})
     return HttpResponse(out + err, content_type="text/plain")


### PR DESCRIPTION
Currently, if a DB host is not configured in settings (like it was on production), Director throws an exception on the other DB type. This PR fixes this bug.