### PR TITLE
Set LANG in web terminal

### DIFF
--- a/node/terminal-handler.js
+++ b/node/terminal-handler.js
@@ -42,7 +42,8 @@ module.exports = {
                         SITE_ROOT: data.site.homedir,
                         SITE_NAME: data.site.name,
                         SITE_PURPOSE: data.site.purpose,
-                        SITE_URL: data.site.url
+                        SITE_URL: data.site.url,
+                        LANG: "en-US.UTF-8"
                     }
                 });
             }


### PR DESCRIPTION
Yes, this hardcodes `en_US.UTF-8`, but I don't think there's another way to set it.