### PR TITLE
Don't mark sites.tjhsst.edu domains as having a custom SSL setup

### DIFF
--- a/web3/apps/sites/models.py
+++ b/web3/apps/sites/models.py
@@ -169,7 +169,7 @@ class Domain(models.Model):
 
     @property
     def custom_ssl(self):
-        return not re.match(r"^[a-zA-Z0-9-]+\.tjhsst\.edu", self.domain)
+        return not re.match(r"^[a-zA-Z0-9-]+(\.sites)?\.tjhsst\.edu", self.domain)
 
     @property
     def has_cert(self):


### PR DESCRIPTION
Makes `SITE_URL`  for project sites use HTTPS instead of HTTP.