### PR TITLE
Add prometheus metrics view

### DIFF
--- a/web3/settings/__init__.py
+++ b/web3/settings/__init__.py
@@ -226,3 +226,5 @@ EMAIL_FROM = "director-noreply@tjhsst.edu"
 
 EMAIL_FEEDBACK = "director@lists.tjhsst.edu"
 EMAIL_CONTACT = "sysadmins@tjhsst.edu"
+
+ALLOWED_METRIC_SCRAPE_IPS = []

--- a/web3/templates/prometheus_metrics.txt
+++ b/web3/templates/prometheus_metrics.txt
@@ -1,0 +1,2 @@
+{% autoescape off %}{% for name, value in metrics.items %}{{ name }} {{ value }}
+{% endfor %}{% endautoescape %}

--- a/web3/urls.py
+++ b/web3/urls.py
@@ -43,7 +43,8 @@ urlpatterns = [
     url(r'^feedback$', feedback_views.feedback_view, name='feedback'),
     url(r'^github_oauth/$', user_views.github_oauth_view),
     url(r'^set_cookie$', auth_views.set_access_cookie_view, name='set_cookie'),
-    url(r'^check_cookie$', auth_views.check_access_cookie_view, name='check_cookie')
+    url(r'^check_cookie$', auth_views.check_access_cookie_view, name='check_cookie'),
+    url(r'^prometheus-metrics$', auth_views.prometheus_metrics_view, name='prometheus_metrics'),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Ported almost directly from Ion's eighth prometheus metrics view (added in tjcsl/ion@f7608b553b96e07385183eb3a1acaf4bd0f709ff). I do not have a development environment, however, so this is completely untested.

Currently, the only metric exports which dynamic sites do not have private directories.