### PR TITLE
Don't display status of sites not owned by user on "All sites" page

### DIFF
--- a/web3/apps/auth/views.py
+++ b/web3/apps/auth/views.py
@@ -33,16 +33,13 @@ def index_view(request):
 
         if request.user.is_superuser and request.GET.get("all", False):
             other_sites = Site.objects.exclude(group__users=request.user).annotate(num_users=Count("group__users")).order_by("name")
-            other_statuses = get_supervisor_statuses(list(other_sites.filter(category="dynamic").values_list("name", flat=True)))
         else:
             other_sites = None
-            other_statuses = None
 
         return render(request, "dashboard.html", {
             "sites": sites,
             "other_sites": other_sites,
             "statuses": statuses,
-            "other_statuses": other_statuses
         })
     else:
         return login_view(request)

--- a/web3/templates/dashboard.html
+++ b/web3/templates/dashboard.html
@@ -58,11 +58,6 @@
         {% if site.num_users <= 1 %}<span data-toggle="tooltip" class="pull-right tag tag-danger tag-nousers">No Users</span>{% endif %}
         {% if site.database %}<span data-toggle="tooltip" class="pull-right tag tag-primary tag-database">{{ site.database.get_category_display }}</span>{% endif %}
         <i class="pull-left fa fa-2x fa-fw {% if site.purpose == 'user' %}fa-user{% elif site.purpose == 'activity' %}fa-globe{% elif site.purpose == 'legacy' %}fa-snowflake-o{% else %}fa-cube{% if site.purpose == 'project' %} project{% endif %}{% endif %}">
-            {% if site.category == "dynamic" %}
-            {% with other_statuses|lookup:site.name as status %}
-            <span class="{% if status is None %}empty{% elif status is True %}green{% else %}red{% endif %}"></span>
-            {% endwith %}
-            {% endif %}
         </i>
         <b class="name">{{ site.name }}</b><span class="sub"><span class="type">{{ site.get_category_display }}</span> - <span class="desc">{{ site.description|default:"No Description" }}</span> - <span class="users">{{ site.num_users|add:"-1" }} user{% if site.num_users != 2 %}s{% endif %}</span></span>
     </a>


### PR DESCRIPTION
This may be the cause of MAJOR slowdowns on that page.

This is completely untested; please review carefully.